### PR TITLE
Enemigos SIEMPRE en pantalla y fix de vida al pasar de level

### DIFF
--- a/server/src/model/game/AnimatedObject.h
+++ b/server/src/model/game/AnimatedObject.h
@@ -41,7 +41,8 @@ public:
     }
 
     void setHealth(int health) {
-        AnimatedObject::health = health;
+        if (health == 99999)
+            AnimatedObject::health = health;
     }
 
     int getDireccionX() {
@@ -68,7 +69,7 @@ public:
     }
 
     int receiveDamage(int damage) { //devuelve la vida que le queda 
-        if (health == 99999){
+        if (health == 99999) {
             return health; // Si la vida es 99999 es super usuario, asique no recibe damage.
         }
         if (health > damage) {
@@ -135,15 +136,15 @@ public:
         AnimatedObject::bulletType = bulletType;
     }
 
-    int getPoints(){
+    int getPoints() {
         return this->puntaje;
     }
 
-    void updateScore(int points){
+    void updateScore(int points) {
         this->puntaje += points;
     }
 
-    void setScore(int points){
+    void setScore(int points) {
         this->puntaje = points;
     }
 };

--- a/server/src/model/game/AnimatedObject.h
+++ b/server/src/model/game/AnimatedObject.h
@@ -142,6 +142,10 @@ public:
     void updateScore(int points){
         this->puntaje += points;
     }
+
+    void setScore(int points){
+        this->puntaje = points;
+    }
 };
 
 #endif //SERVER_ANIMATEDOBJECT_H

--- a/server/src/model/game/AnimatedObject.h
+++ b/server/src/model/game/AnimatedObject.h
@@ -41,7 +41,7 @@ public:
     }
 
     void setHealth(int health) {
-        if (health == 99999)
+        if (health != 99999)
             AnimatedObject::health = health;
     }
 

--- a/server/src/model/game/BulletMovementStrategy.cpp
+++ b/server/src/model/game/BulletMovementStrategy.cpp
@@ -8,7 +8,7 @@ void BulletMovementStrategy::makeCollision(vector<GameObject *> collisionables, 
     Bullet *bullet = (Bullet *) gameObject;
     for (auto object : collisionables) {
         if (bullet->puedenColisionar(object) && object->checkCollition(bullet)) {
-            if (object->getEntity() != MSC_PLATFORM) {
+            if (object->getEntity() != MSC_PLATFORM && ((AnimatedObject*)object)->getPostura() != DESCONECTADO) {
                 AnimatedObject *animatedObject = (AnimatedObject *) object;
                 if (animatedObject->receiveDamage(bullet->getDamage()) > 0 and (animatedObject->getEntity() == ENEMY_NORMAL_1 or animatedObject->getEntity() == ENEMY_NORMAL_2 or animatedObject->getEntity() == ENEMY_NORMAL_3
                     or animatedObject->getEntity() == ENEMY_FINAL_1 or animatedObject->getEntity() == ENEMY_FINAL_2 or animatedObject->getEntity() == ENEMY_FINAL_3) ){

--- a/server/src/model/game/PlayerBuilder.cpp
+++ b/server/src/model/game/PlayerBuilder.cpp
@@ -32,6 +32,6 @@ int PlayerBuilder::getHealth() {
     if (mode.testMode){
         return 999999;
     }
-    return 1000;
+    return 100;
 }
 

--- a/server/src/model/game/Scenery.cpp
+++ b/server/src/model/game/Scenery.cpp
@@ -26,6 +26,8 @@ void Scenery::setUpLevel(int selectedLevel) {
     // Esto es para resetear la posicion de los players
     if (selectedLevel > 1) {
         for (auto player: players) {
+            player->setHealth(100); //Habria que ver si a los desconectados, les recargamos la vida
+            // player->setScore(0); //Al cambiar de nivel, se renueva el score
             if (player->getPostura() != DESCONECTADO){
                 player->set_position(0, 0);
             }
@@ -175,7 +177,11 @@ int Scenery::updateBackgroudsState() {
             }
 
             for (auto &enemy : enemies) {
-                enemy->retroceder();
+                if (enemy->getX() > 10){ 
+                    enemy->retroceder();
+                } else {
+                    enemy->setPostura(CAMINANDO_DERECHA);
+                }
             }
         }
     } else {
@@ -280,6 +286,7 @@ void Scenery::updateEnemiesState(vector<GameObject *> &all_objects_in_window) {
         enemy->updatePosition(all_objects_in_window);
         makeEnemyShoot(enemy);
         makeEnemyDropEnemies(enemy);
+        cout << "ACA VIENE LA POS: "<< enemy->getX() << endl;
     }
 }
 

--- a/server/src/model/game/Scenery.cpp
+++ b/server/src/model/game/Scenery.cpp
@@ -286,7 +286,6 @@ void Scenery::updateEnemiesState(vector<GameObject *> &all_objects_in_window) {
         enemy->updatePosition(all_objects_in_window);
         makeEnemyShoot(enemy);
         makeEnemyDropEnemies(enemy);
-        cout << "ACA VIENE LA POS: "<< enemy->getX() << endl;
     }
 }
 
@@ -422,6 +421,7 @@ void Scenery::removeDeadBullets() {
         if ((*it)->getEntity() == DEAD ||
             !((*it)->getX() <= windowWidth && (*it)->getX() >= 0 && (*it)->getY() <= windowHeight &&
               (*it)->getY() >= 0)) {
+            delete (*it);
             it = bullets.erase(it);
         } else {
             ++it;
@@ -451,6 +451,7 @@ void Scenery::removeDeadEnemies() {
     vector<Enemy *>::iterator it = enemies.begin();
     while (it != enemies.end()) {
         if ((*it)->getPostura() == MUERTO) {
+            delete (*it);
             it = enemies.erase(it);
         }
         else if (((*it)->getPostura() == MURIENDO) and ((*it)->getHealth() <= -400)) {

--- a/server/src/model/game/Scenery.cpp
+++ b/server/src/model/game/Scenery.cpp
@@ -179,7 +179,7 @@ int Scenery::updateBackgroudsState() {
             for (auto &enemy : enemies) {
                 if (enemy->getX() > 10){ 
                     enemy->retroceder();
-                } else {
+                } else if (enemy->getPostura() != MURIENDO && enemy->getPostura() != MUERTO){
                     enemy->setPostura(CAMINANDO_DERECHA);
                 }
             }


### PR DESCRIPTION
Ahora los enemigos no se van mas de pantalla, ya que al actualizar
el background chequea si los puede mover o no.

A parte de esto, baje la vida a 100 que me parece mas realista,
y cambie en setup level que cuando pasas de nivel recarge la vida.

Por ultimo agregue un setScore por si llegamos a decidir que si se cambia
de nivel, se resetee el score, ya esta la funcion puesta pero comentada
en el scenary, en setup level... porque habria que charlarlo. Pero si
lo llegaran a pedir maniana es solo descomentarlo.